### PR TITLE
Do not fail when isolcpus is not configured

### DIFF
--- a/epa_orchestrator/cpu_pinning.py
+++ b/epa_orchestrator/cpu_pinning.py
@@ -19,9 +19,6 @@ def get_isolated_cpus() -> str:
 
     Returns:
         str: Comma-separated list of CPU ranges that are isolated
-
-    Raises:
-        RuntimeError: If no isolated CPUs are configured
     """
     try:
         with open(ISOLATED_CPUS_PATH, "r") as f:
@@ -29,11 +26,10 @@ def get_isolated_cpus() -> str:
             if value:
                 logging.info(f"Found isolated CPUs: {value}")
                 return value
-        logging.error("No Isolated CPUs configured")
-        raise RuntimeError("No Isolated CPUs configured")
+        logging.info("No Isolated CPUs configured")
     except Exception as e:
         logging.error(f"Failed to get CPU information: {e}")
-        raise RuntimeError("No Isolated CPUs configured") from e
+    return ""
 
 
 def calculate_cpu_pinning(cpu_list: str, cores_requested: int = 0) -> "tuple[str, str]":

--- a/epa_orchestrator/daemon_handler.py
+++ b/epa_orchestrator/daemon_handler.py
@@ -41,10 +41,7 @@ def handle_allocate_cores(request: AllocateCoresRequest) -> AllocateCoresRespons
     if request.numa_node is not None:
         raise ValueError("'numa_node' is not allowed for action allocate_cores")
 
-    try:
-        isolated = get_isolated_cpus()
-    except RuntimeError as e:
-        raise ValueError("No Isolated CPUs configured") from e
+    isolated = get_isolated_cpus()
     if not isolated:
         raise ValueError("No CPUs available")
 
@@ -118,6 +115,9 @@ def handle_allocate_numa_cores(
             total_available_cpus=stats["total_available_cpus"],
             remaining_available_cpus=updated_stats["remaining_available_cpus"],
         )
+
+    if not isolated:
+        raise ValueError("No Isolated CPUs available for allocation")
 
     # Allocation path (num_of_cores > 0)
     available_numa_cpus = get_cpus_in_numa_node(request.numa_node, isolated)
@@ -258,17 +258,7 @@ def handle_list_allocations(request: ListAllocationsRequest) -> ListAllocationsR
     Returns:
         ListAllocationsResponse with detailed allocation information
     """
-    try:
-        isolated = get_isolated_cpus()
-    except RuntimeError:
-        # Return empty response when no isolated CPUs are configured
-        return ListAllocationsResponse(
-            total_allocations=0,
-            total_allocated_cpus=0,
-            total_available_cpus=0,
-            remaining_available_cpus=0,
-            allocations=[],
-        )
+    isolated = get_isolated_cpus()
     if not isolated:
         # Return empty response when no isolated CPUs are available
         return ListAllocationsResponse(

--- a/tests/functional/test_socket_api.py
+++ b/tests/functional/test_socket_api.py
@@ -28,7 +28,7 @@ def test_allocate_cores_via_socket_api(socket_path):
 
     if "error" in result:
         # Acceptable if no isolated CPUs are configured
-        assert "No Isolated CPUs configured" in result["error"]
+        assert "No CPUs available" in result["error"]
     else:
         assert result["version"] == "1.0"
         assert result["service_name"] == "test-service"

--- a/tests/unit/test_cpu_pinning.py
+++ b/tests/unit/test_cpu_pinning.py
@@ -5,8 +5,6 @@
 
 from unittest.mock import mock_open, patch
 
-import pytest
-
 from epa_orchestrator.cpu_pinning import calculate_cpu_pinning, get_isolated_cpus
 
 
@@ -97,8 +95,16 @@ class TestCpuPinning:
         mock_logging.info.assert_called()
 
     def test_get_isolated_cpus_no_isolated(self, mock_logging):
-        """Test error when no isolated CPUs are configured."""
+        """Test behavior when no isolated CPUs are configured."""
         m = mock_open(read_data="")
         with patch("builtins.open", m):
-            with pytest.raises(RuntimeError, match="No Isolated CPUs configured"):
-                get_isolated_cpus()
+            result = get_isolated_cpus()
+            assert result == ""
+            # No logging should happen for empty file
+
+    def test_get_isolated_cpus_file_not_found(self, mock_logging):
+        """Test behavior when isolated CPUs file doesn't exist."""
+        with patch("builtins.open", side_effect=FileNotFoundError("File not found")):
+            result = get_isolated_cpus()
+            assert result == ""
+            mock_logging.error.assert_called_with("Failed to get CPU information: File not found")

--- a/tests/unit/test_daemon_integration.py
+++ b/tests/unit/test_daemon_integration.py
@@ -80,7 +80,7 @@ class TestDaemonIntegration:
         """Test error response when no isolated CPUs are configured in daemon handler."""
         with patch(
             "epa_orchestrator.cpu_pinning.get_isolated_cpus",
-            side_effect=RuntimeError("No Isolated CPUs configured"),
+            return_value="",
         ):
             request = {
                 "version": "1.0",
@@ -90,7 +90,21 @@ class TestDaemonIntegration:
             }
             response_bytes = handle_daemon_request(bytes(str(request).replace("'", '"'), "utf-8"))
             resp = parse_obj_as(ErrorResponse, json.loads(response_bytes.decode()))
-            assert resp.error == "No Isolated CPUs configured"
+            assert resp.error == "No CPUs available"
+
+    def test_allocate_numa_cores_no_isolated_cpus(self):
+        """Test error when no isolated CPUs are available for NUMA allocation."""
+        request = {
+            "version": "1.0",
+            "service_name": "service1",
+            "action": "allocate_numa_cores",
+            "numa_node": 0,
+            "num_of_cores": 2,
+        }
+        with patch("epa_orchestrator.cpu_pinning.get_isolated_cpus", return_value=""):
+            response_bytes = handle_daemon_request(json.dumps(request).encode())
+            resp = parse_obj_as(ErrorResponse, json.loads(response_bytes.decode()))
+            assert resp.error == "No Isolated CPUs available for allocation"
 
     @patch("epa_orchestrator.daemon_handler.get_memory_summary")
     def test_allocate_hugepages_track_positive(self, mock_summary):


### PR DESCRIPTION
Consider not configured isolcpus as having no isolcpu available instead of failing the request.

In case of deallocating, response should be successful but equivalent to a no-op.
In case of allocation, response should be unsuccessful, with not CPUs available to be allocated.

Fix: #7